### PR TITLE
go for 0.1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.3" %}
+{% set version = "0.1.4" %}
 {% set name = "atmosphere-virtual-lab" %}
 
 package:
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/stcorp/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
-  sha256: 6ceb8f0c78ab4c8e9ab5b913c09cebc1cfb589074c7515aca3787b18e873703f
+  sha256: 46b266bb27dbf981f36231c15061b93a8e2a720cf82b0030e223f37c0f54fda2
 
 build:
   number: 0
@@ -25,9 +25,11 @@ requirements:
 
   run:
     - jupyterlab >=3
+    - jupytext
     - python >=3.9
     - requests
     - coda
+    - ipyleaflet-gl-vector-layer-plugin
     - ipyleaflet =0.15.0
     - harp
     - panel =0.12.7


### PR DESCRIPTION
-use 0.1.4 with several fixes, most importantly now comes with
 8k_earth_daymap.jpg
-add ipyleaflet-gl-vector-layer-plugin dependency, now that it's
in conda-forge
-add jupytext dependency

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
